### PR TITLE
Update call-for-papers.md

### DIFF
--- a/call-for-papers.md
+++ b/call-for-papers.md
@@ -25,8 +25,9 @@ Solicited topics include, but are not limited to:
 
 * Machine learning methods and algorithms (classification, regression, unsupervised and semi-supervised learning, clustering, logic programming, ...) 
 * Probabilistic methods (Bayesian methods, approximate inference, density estimation, tractable probabilistic models, probabilistic programming, ...)
-* Theory of machine learning and statistics (optimization, computational learning theory, decision theory and bandits, game theory, frequentist statistics,  information theory, ...) 
-* Deep learning (theory, architectures, reinforcement learning, generative models, optimization for neural networks, ...)
+* Theory of machine learning and statistics (optimization, computational learning theory, decision theory, online leaning and bandits, game theory, frequentist statistics, information theory, ...) 
+* Deep learning (theory, architectures, generative models, optimization for neural networks, ...)
+* Reinforcement learning (theory of RL, offline/online RL, deep RL, multi-agent RL, ...)
 * Ethical and trustworthy machine learning (causality, fairness, interpretability, privacy, robustness, safety, ...) 
 * Applications of machine learning and statistics (including natural language, signal processing, computer vision, physical sciences, social sciences, sustainability and climate, healthcare, ...)
 


### PR DESCRIPTION
Added a bullet for Reinforcement learning on its own.

Accordingly, removed "reinforcement learning" form the parenthesised list under the bullet for Deep Learning.

In the bullet "Theory of machine learning and statistics" in the parenthesised list, separated "decision making and bandits," into "decision making," and "online learning and bandits,"