### PR TITLE
Change rebuttal dates from 2024 to 2023

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -94,12 +94,12 @@ conference:
       text: 20 October 2023
       date: 20 October 2023
     - name: Reviews released
-      text: 27 November 2024
-      date: 27 November 2024
+      text: 27 November 2023
+      date: 27 November 2023
     - name: Author rebuttals due
       type: submission
-      text: 5 December 2024 (Anywhere on Earth)
-      date: 5 December 2024
+      text: 5 December 2023 (Anywhere on Earth)
+      date: 5 December 2023
     - name: Paper decision notifications
       type: decision
       text: 19 January 2024


### PR DESCRIPTION
The review and rebuttal dates are set to 2024. I hope this year's reviewers won't be that slow ;)